### PR TITLE
Permit to run vuejs-webpack-boilerplate in cross environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "start": "NODE_ENV=development PORT=3000 babel-node server",
-    "build": "NODE_ENV=production webpack --config webpack/webpack.prod.config.babel.js --progress --profile --colors",
+    "start": "cross-env NODE_ENV=development PORT=3000 babel-node server",
+    "build": "cross-env NODE_ENV=production webpack --config webpack/webpack.prod.config.babel.js --progress --profile --colors",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
@@ -54,6 +54,7 @@
     "clean-webpack-plugin": "^0.1.6",
     "connect-history-api-fallback": "^1.1.0",
     "copy-webpack-plugin": "^1.0.0",
+    "cross-env": "^3.1.4",
     "css-loader": "^0.23.1",
     "eslint": "2.4.0",
     "eslint-loader": "^1.2.0",


### PR DESCRIPTION
Base project do not allow to run in Windows env. Using the npm package cross-env it now runs everywhere.

ps : I should send more PR soon to update to Webpack2, VueJS2, add Gulp support and update as well the ThreeJS repo with latest Threejs. Just to keep things maitained. Stay tuned.